### PR TITLE
Apply hints suggested by the [multi-arch hinter](https://wiki.debian.org/MultiArch/Hints)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,6 +28,7 @@ Priority: extra
 Architecture: all
 Depends: ${misc:Depends}, ${perl:Depends}
 Breaks: dkimproxy (<= 1.4.1-3)
+Multi-Arch: foreign
 Description: SMTP Client/Server modules from smtpprox
  Includes the Client.pm and Server.pm SMTP modules from smtpprox
  at http://bent.latency.net/smtpprox/ with Debian enhancements.


### PR DESCRIPTION
Apply hints suggested by the [multi-arch hinter](https://wiki.debian.org/MultiArch/Hints).

* libmsdw-smtp-perl: Add Multi-Arch: foreign.. This fixes: libmsdw-smtp-perl could be marked Multi-Arch: foreign. ([ma-foreign](https://wiki.debian.org/MultiArch/Hints#ma-foreign))

Note that in some cases, these multi-arch hints may trigger lintian warnings until the dependencies of the package support multi-arch. This is expected, see [https://janitor.debian.net/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/multiarch-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/multiarch-fixes/pkg/smtpprox/349b6675-2e4c-4e83-91ab-a09f76b79d38.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package libmsdw-smtp-perl: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}

No differences were encountered between the control files of package \*\*smtpprox\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/349b6675-2e4c-4e83-91ab-a09f76b79d38/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/349b6675-2e4c-4e83-91ab-a09f76b79d38/diffoscope)).
